### PR TITLE
Fixes a typo in form_values()

### DIFF
--- a/alfajor/browsers/_lxml.py
+++ b/alfajor/browsers/_lxml.py
@@ -311,9 +311,7 @@ class FormElement(object):
                     elif el.multiple:
                         for v in value:
                             results.append((name, v))
-                            continue
-                    if results:
-                        return results
+                        continue
                 elif type == 'file':
                     if value:
                         mimetype = mimetypes.guess_type(value)[0] \


### PR DESCRIPTION
I inadvertently added a bug that the tests did not catch.  In reality what needed to happen was a de-indentation of a continue from a for statement, instead of my previous change.  Tested here and in our development environment that uses this patch.
